### PR TITLE
Fix mobile navigation

### DIFF
--- a/src/app/components/nav-menu/nav-menu.component.html
+++ b/src/app/components/nav-menu/nav-menu.component.html
@@ -38,12 +38,12 @@
        [@navCollapsed]="isCollapsed"
        (click)="isCollapsed = true">
     <ul class="nav">
-      <li *ngFor="let item of linkList">
-        <a [routerLink]="item.link">{{ item.text }}</a>
-      </li>
       <li *ngFor="let item of scrollList">
         <a class="scroll-link"
            (click)="scrollTo(item.link)">{{ item.text }}</a>
+      </li>
+      <li *ngFor="let item of linkList">
+          <a [routerLink]="item.link">{{ item.text }}</a>
       </li>
     </ul>
   </div>
@@ -57,7 +57,8 @@
       <!-- brand logo -->
       <div class="brand-logo">
         <img src="../../../assets/navlogo.png"
-             alt="brand logo">
+             alt="brand logo"
+             routerLink="/">
       </div>
       <!-- Menu Options -->
       <div class="navbar-menu-options">

--- a/src/app/components/nav-menu/nav-menu.component.scss
+++ b/src/app/components/nav-menu/nav-menu.component.scss
@@ -12,10 +12,11 @@
 	width: 100%;
 
 	.brand-logo {
-		padding: 15px 50px 10px 20px;
+        padding: 15px 50px 10px 20px;
+        cursor: pointer;
 		img {
 			width: 150px;
-		}
+        }
 	}
 
 	.navbar-menu-options {
@@ -53,7 +54,7 @@
 }
 .toggle-button {
   position: fixed;
-  top: 20px;
+  top: 80px;
   right: 0px;
   margin: 0;
   padding: 20px;


### PR DESCRIPTION
Moved 'examples' link to bottom of mobile nav, and bumped mobile tab position further down